### PR TITLE
Add support for integer (whole number) values

### DIFF
--- a/Classes/MPFormatterUtils.h
+++ b/Classes/MPFormatterUtils.h
@@ -38,8 +38,10 @@
 + (NSString *)shortStringFromPercentage:(NSNumber *)number locale:(NSLocale *)locale;
 + (NSString *)stringFromCurrency:(NSNumber *)currency locale:(NSLocale *)locale;
 + (NSString *)stringFromNumber:(NSNumber *)currency locale:(NSLocale *)locale;
++ (NSString *)stringFromInteger:(NSNumber *)integer locale:(NSLocale *)locale;
 + (NSNumber *)numberFromString:(NSString *)string locale:(NSLocale *)locale;
 + (NSNumber *)currencyFromString:(NSString *)string locale:(NSLocale *)locale;
 + (NSNumber *)percentageFromString:(NSString *)string locale:(NSLocale *)locale;
++ (NSNumber *)integerFromString:(NSString *)string locale:(NSLocale *)locale;
 
 @end

--- a/Classes/MPFormatterUtils.m
+++ b/Classes/MPFormatterUtils.m
@@ -120,6 +120,21 @@
 	return formatted;
 }
 
++ (NSString *)stringFromInteger:(NSNumber *)integer locale:(NSLocale *)locale
+{
+    // get formatted string
+    NSNumberFormatter * myNumFormatter = [[NSNumberFormatter alloc] init];
+    [myNumFormatter setLocale:locale];
+    [myNumFormatter setFormatterBehavior:NSNumberFormatterBehavior10_4];
+    [myNumFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
+    [myNumFormatter setGeneratesDecimalNumbers:NO];
+    [myNumFormatter setMinimumFractionDigits:0];
+    [myNumFormatter setMaximumFractionDigits:0];
+    
+    NSString* formatted = [myNumFormatter stringFromNumber:integer];
+    return formatted;
+}
+
 + (NSNumber *)numberFromString:(NSString *)string locale:(NSLocale *)locale
 {
 	// localization allows other thousands separators, also.
@@ -131,6 +146,22 @@
 	NSNumber *tempNum = [myNumFormatter numberFromString:string];
 	
 	return tempNum;
+}
+
++ (NSNumber *)integerFromString:(NSString *)string locale:(NSLocale *)locale
+{
+    // localization allows other thousands separators, also.
+    NSNumberFormatter * myNumFormatter = [[NSNumberFormatter alloc] init];
+    [myNumFormatter setLocale:locale];
+    [myNumFormatter setFormatterBehavior:NSNumberFormatterBehavior10_4];
+    [myNumFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
+    [myNumFormatter setGeneratesDecimalNumbers:NO];
+    [myNumFormatter setMinimumFractionDigits:0];
+    [myNumFormatter setMaximumFractionDigits:0];
+    
+    NSNumber *tempNum = [myNumFormatter numberFromString:string];
+    
+    return [NSNumber numberWithInt:tempNum.intValue];
 }
 
 + (NSNumber *)currencyFromString:(NSString *)string locale:(NSLocale *)locale

--- a/Classes/MPNumericTextField.h
+++ b/Classes/MPNumericTextField.h
@@ -33,10 +33,11 @@
 #import "MPNumericTextFieldDelegate.h"
 #import "MPFormatterUtils.h"
 
-enum MPNumericTextFieldType {
+typedef NS_ENUM(NSUInteger, MPNumericTextFieldType) {
   MPNumericTextFieldDecimal = 0,
   MPNumericTextFieldCurrency,
-  MPNumericTextFieldPercentage
+  MPNumericTextFieldPercentage,
+  MPNumericTextFieldInteger
 };
 
 IB_DESIGNABLE
@@ -44,7 +45,7 @@ IB_DESIGNABLE
 
 @property (nonatomic, copy)   NSString                     *encodedValue;
 @property (nonatomic, strong) IBInspectable UIColor        *placeholderColor;
-@property (nonatomic, assign) enum MPNumericTextFieldType   type;
+@property (nonatomic, assign) MPNumericTextFieldType        type;
 @property (nonatomic, strong) NSLocale                     *locale;
 @property (nonatomic, assign) NSNumber                     *numericValue;
 @property (nonatomic, readonly) id<UITextFieldDelegate>     forwardDelegate;

--- a/Classes/MPNumericTextField.m
+++ b/Classes/MPNumericTextField.m
@@ -76,14 +76,22 @@ MPNumericTextFieldDelegate *numericDelegate;
   switch (type) {
     case MPNumericTextFieldPercentage:
       self.placeholder = [MPFormatterUtils stringFromPercentage:@(0) locale:self.locale];
+      self.keyboardType = UIKeyboardTypeDecimalPad;
       break;
 
     case MPNumericTextFieldCurrency:
       self.placeholder = [MPFormatterUtils stringFromCurrency:@(0) locale:self.locale];
+      self.keyboardType = UIKeyboardTypeDecimalPad;
       break;
 
     case MPNumericTextFieldDecimal:
       self.placeholder = [MPFormatterUtils stringFromNumber:@(0) locale:self.locale];
+      self.keyboardType = UIKeyboardTypeDecimalPad;
+      break;
+    
+    case MPNumericTextFieldInteger:
+      self.placeholder = [MPFormatterUtils stringFromInteger:@(0) locale:self.locale];
+      self.keyboardType = UIKeyboardTypeNumberPad;
       break;
   }
 }
@@ -130,6 +138,9 @@ MPNumericTextFieldDelegate *numericDelegate;
     case MPNumericTextFieldPercentage:
       self.encodedValue = [MPFormatterUtils stringFromPercentage:value locale:_locale];
       break;
+    case MPNumericTextFieldInteger:
+      self.encodedValue = [MPFormatterUtils stringFromInteger:value locale:_locale];
+      break;
   }
   
   self.text = self.encodedValue;
@@ -143,6 +154,8 @@ MPNumericTextFieldDelegate *numericDelegate;
       return [MPFormatterUtils numberFromString:_encodedValue locale:_locale];
     case MPNumericTextFieldPercentage:
       return [MPFormatterUtils percentageFromString:_encodedValue locale:_locale];
+    case MPNumericTextFieldInteger:
+      return [MPFormatterUtils integerFromString:_encodedValue locale:_locale];
   }
 }
 

--- a/Classes/MPNumericTextField.m
+++ b/Classes/MPNumericTextField.m
@@ -70,7 +70,7 @@ MPNumericTextFieldDelegate *numericDelegate;
   self.textAlignment = NSTextAlignmentRight;
 }
 
-- (void) setType:(enum MPNumericTextFieldType)type {
+- (void) setType:(MPNumericTextFieldType)type {
   _type = type;
   
   switch (type) {

--- a/Classes/MPNumericTextFieldDelegate.m
+++ b/Classes/MPNumericTextFieldDelegate.m
@@ -155,6 +155,9 @@
         n = [MPFormatterUtils percentageFromString:fxText.encodedValue locale:locale];
         n = @(round(([n doubleValue] * 10000))/10);
         break;
+      case MPNumericTextFieldInteger:
+        n = [MPFormatterUtils integerFromString:fxText.encodedValue locale:locale];
+        break;
     }
     
     NSMutableString* mstring = [[n stringValue] mutableCopy];
@@ -202,6 +205,9 @@
         number = [MPFormatterUtils percentageFromString:mstring locale:locale];
         fxText.encodedValue = [MPFormatterUtils stringFromPercentage:number locale:locale];
         break;
+      case MPNumericTextFieldInteger:
+        number = @(number.integerValue);
+        fxText.encodedValue = [MPFormatterUtils stringFromInteger:number locale:locale];
     }
   }
   


### PR DESCRIPTION
You can now change the text field type to "Integer".  It works basically the same as "Decimal", but with the fractional part removed.  The numeric keyboard is used instead of the decimal keyboard, so the user can't enter a decimal point.

Changing enum to NS_ENUM makes it so that a Swift enum `MPNumericTextFieldType` will be generated with the cases `Decimal`, `Currency`, `Percentage`, and `Integer`.  It's also backward compatible with Objective-C code.
