### PR TITLE
Reset cached formatters if the locale property has changed

### DIFF
--- a/Classes/MPFormatterUtils.m
+++ b/Classes/MPFormatterUtils.m
@@ -36,7 +36,7 @@
 + (NSNumberFormatter *)currencyFormatter:(NSLocale *)locale
 {
   static NSNumberFormatter *currencyFormatter;
-  if (!currencyFormatter) {
+  if (!currencyFormatter || currencyFormatter.locale != locale) {
     currencyFormatter  = [[NSNumberFormatter alloc] init];
     [currencyFormatter setLocale:locale];
     [currencyFormatter setFormatterBehavior:NSNumberFormatterBehaviorDefault];
@@ -60,7 +60,7 @@
 	}
 	
 	static NSNumberFormatter *percentFormatter;
-	if (percentFormatter == NULL) {
+	if (percentFormatter == NULL || percentFormatter.locale != locale) {
 		percentFormatter  = [[NSNumberFormatter alloc] init];
     percentFormatter.locale = locale;
 		[percentFormatter setGeneratesDecimalNumbers:YES];
@@ -84,7 +84,7 @@
 	}
 	
 	static NSNumberFormatter *percentFormatter;
-	if (percentFormatter == NULL) {
+	if (percentFormatter == NULL || percentFormatter.locale != locale) {
 		percentFormatter  = [[NSNumberFormatter alloc] init];
     percentFormatter.locale = locale;
 		[percentFormatter setGeneratesDecimalNumbers:YES];


### PR DESCRIPTION
When setting a custom `locale` on the text field, it wasn't rendering correctly. This can be seen in the demo app by adding the line

    _currencyField.locale = [NSLocale localeWithLocaleIdentifier:@"ja_JP"];

It turns out that the `MPFormatterUtils` class is caching instances of `NSNmberFormatter`, but not refreshing the cached formatter if the locale has changed.