### PR TITLE
Add support for country code independent of locale

### DIFF
--- a/Classes/MPFormatterUtils.h
+++ b/Classes/MPFormatterUtils.h
@@ -33,14 +33,14 @@
 
 @interface MPFormatterUtils : NSObject
 
-+ (NSNumberFormatter *)currencyFormatter:(NSLocale *)locale;
++ (NSNumberFormatter *)currencyFormatter:(NSLocale *)locale currencyCode:(NSString *)code;
 + (NSString *)stringFromPercentage:(NSNumber *)number locale:(NSLocale *)locale;
 + (NSString *)shortStringFromPercentage:(NSNumber *)number locale:(NSLocale *)locale;
-+ (NSString *)stringFromCurrency:(NSNumber *)currency locale:(NSLocale *)locale;
++ (NSString *)stringFromCurrency:(NSNumber *)currency locale:(NSLocale *)locale currencyCode:(NSString *)code;
 + (NSString *)stringFromNumber:(NSNumber *)currency locale:(NSLocale *)locale;
 + (NSString *)stringFromInteger:(NSNumber *)integer locale:(NSLocale *)locale;
 + (NSNumber *)numberFromString:(NSString *)string locale:(NSLocale *)locale;
-+ (NSNumber *)currencyFromString:(NSString *)string locale:(NSLocale *)locale;
++ (NSNumber *)currencyFromString:(NSString *)string locale:(NSLocale *)locale currencyCode:(NSString *)code;
 + (NSNumber *)percentageFromString:(NSString *)string locale:(NSLocale *)locale;
 + (NSNumber *)integerFromString:(NSString *)string locale:(NSLocale *)locale;
 

--- a/Classes/MPFormatterUtils.m
+++ b/Classes/MPFormatterUtils.m
@@ -33,12 +33,15 @@
 
 @implementation MPFormatterUtils
 
-+ (NSNumberFormatter *)currencyFormatter:(NSLocale *)locale
++ (NSNumberFormatter *)currencyFormatter:(NSLocale *)locale currencyCode:(NSString *)code
 {
   static NSNumberFormatter *currencyFormatter;
-  if (!currencyFormatter || currencyFormatter.locale != locale) {
+  if (!currencyFormatter || currencyFormatter.locale != locale || (code != nil && currencyFormatter.currencyCode != code)) {
     currencyFormatter  = [[NSNumberFormatter alloc] init];
     [currencyFormatter setLocale:locale];
+    if (code) {
+      [currencyFormatter setCurrencyCode:code];
+    }
     [currencyFormatter setFormatterBehavior:NSNumberFormatterBehaviorDefault];
     [currencyFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
     
@@ -101,10 +104,10 @@
 	return formatted;
 }
 
-+ (NSString *)stringFromCurrency:(NSNumber *)currency locale:(NSLocale *)locale
++ (NSString *)stringFromCurrency:(NSNumber *)currency locale:(NSLocale *)locale currencyCode:(NSString *)code
 {
 	// get formatted string
-	NSString* formatted = [[self currencyFormatter:locale] stringFromNumber:currency];
+    NSString* formatted = [[self currencyFormatter:locale currencyCode:code] stringFromNumber:currency];
 	return formatted;
 }
 
@@ -164,9 +167,9 @@
     return [NSNumber numberWithInt:tempNum.intValue];
 }
 
-+ (NSNumber *)currencyFromString:(NSString *)string locale:(NSLocale *)locale
++ (NSNumber *)currencyFromString:(NSString *)string locale:(NSLocale *)locale currencyCode:(NSString *)code
 {
-  NSNumberFormatter *currencyFormatter = [self currencyFormatter:locale];
+  NSNumberFormatter *currencyFormatter = [self currencyFormatter:locale currencyCode:code];
   return [currencyFormatter numberFromString:string];
 }
 

--- a/Classes/MPNumericTextField.h
+++ b/Classes/MPNumericTextField.h
@@ -47,6 +47,7 @@ IB_DESIGNABLE
 @property (nonatomic, strong) IBInspectable UIColor        *placeholderColor;
 @property (nonatomic, assign) MPNumericTextFieldType        type;
 @property (nonatomic, strong) NSLocale                     *locale;
+@property (nonatomic, strong) NSString                     *currencyCode;
 @property (nonatomic, assign) NSNumber                     *numericValue;
 @property (nonatomic, readonly) id<UITextFieldDelegate>     forwardDelegate;
 

--- a/Classes/MPNumericTextField.m
+++ b/Classes/MPNumericTextField.m
@@ -64,7 +64,7 @@ MPNumericTextFieldDelegate *numericDelegate;
 
 - (void) setDefaults {
   self.locale = [NSLocale currentLocale];
-  self.currencyCode = self.locale.currencyCode;
+  self.currencyCode = [self.locale objectForKey:NSLocaleCurrencyCode];
   self.keyboardType = UIKeyboardTypeDecimalPad;
   self.type = MPNumericTextFieldDecimal;
   self.delegate = self.numericDelegate;

--- a/Classes/MPNumericTextField.m
+++ b/Classes/MPNumericTextField.m
@@ -64,6 +64,7 @@ MPNumericTextFieldDelegate *numericDelegate;
 
 - (void) setDefaults {
   self.locale = [NSLocale currentLocale];
+  self.currencyCode = self.locale.currencyCode;
   self.keyboardType = UIKeyboardTypeDecimalPad;
   self.type = MPNumericTextFieldDecimal;
   self.delegate = self.numericDelegate;
@@ -80,7 +81,7 @@ MPNumericTextFieldDelegate *numericDelegate;
       break;
 
     case MPNumericTextFieldCurrency:
-      self.placeholder = [MPFormatterUtils stringFromCurrency:@(0) locale:self.locale];
+      self.placeholder = [MPFormatterUtils stringFromCurrency:@(0) locale:self.locale currencyCode:self.currencyCode];
       self.keyboardType = UIKeyboardTypeDecimalPad;
       break;
 
@@ -130,7 +131,7 @@ MPNumericTextFieldDelegate *numericDelegate;
 - (void) setNumericValue:(NSNumber *)value {
   switch (_type) {
     case MPNumericTextFieldCurrency:
-      self.encodedValue = [MPFormatterUtils stringFromCurrency:value locale:_locale];
+      self.encodedValue = [MPFormatterUtils stringFromCurrency:value locale:_locale currencyCode:_currencyCode];
       break;
     case MPNumericTextFieldDecimal:
       self.encodedValue = [MPFormatterUtils stringFromNumber:value locale:_locale];
@@ -149,7 +150,7 @@ MPNumericTextFieldDelegate *numericDelegate;
 - (NSNumber *)numericValue {
   switch (_type) {
     case MPNumericTextFieldCurrency:
-      return [MPFormatterUtils currencyFromString:_encodedValue locale:_locale];
+      return [MPFormatterUtils currencyFromString:_encodedValue locale:_locale currencyCode:_currencyCode];
     case MPNumericTextFieldDecimal:
       return [MPFormatterUtils numberFromString:_encodedValue locale:_locale];
     case MPNumericTextFieldPercentage:

--- a/Classes/MPNumericTextFieldDelegate.m
+++ b/Classes/MPNumericTextFieldDelegate.m
@@ -118,7 +118,8 @@
   
   MPNumericTextField *fxText = (MPNumericTextField *)textField;
   NSLocale *locale = fxText.locale;
-  NSNumberFormatter *currencyFormatter = [MPFormatterUtils currencyFormatter:locale];
+  NSString *currencyCode = fxText.currencyCode;
+  NSNumberFormatter *currencyFormatter = [MPFormatterUtils currencyFormatter:locale currencyCode:currencyCode];
   
   NSMutableCharacterSet *numberSet = [[NSCharacterSet decimalDigitCharacterSet] mutableCopy];
   [numberSet formUnionWithCharacterSet:[NSCharacterSet whitespaceCharacterSet]];
@@ -142,7 +143,7 @@
     
     switch (fxText.type) {
       case MPNumericTextFieldCurrency:
-        n = [MPFormatterUtils currencyFromString:fxText.encodedValue locale:locale];
+        n = [MPFormatterUtils currencyFromString:fxText.encodedValue locale:locale currencyCode:currencyCode];
         mul = pow(10, [currencyFormatter maximumFractionDigits] + 1);
         n = @(round(([n doubleValue] * mul))/10);
         break;
@@ -195,7 +196,7 @@
     switch (fxText.type) {
       case MPNumericTextFieldCurrency:
         number = @(number.doubleValue / rate);
-        fxText.encodedValue = [MPFormatterUtils stringFromCurrency:number locale:locale];
+        fxText.encodedValue = [MPFormatterUtils stringFromCurrency:number locale:locale currencyCode:currencyCode];
         break;
       case MPNumericTextFieldDecimal:
         number = @(number.doubleValue / rate);


### PR DESCRIPTION
Previously, the only way to set a different currency was via the `locale` property. This is not always sufficient, for example when a user wants to see a currency that is not the same as their locale.

The separation of locale and currency can be seen in`NSNumberFormatter`, which has both `locale` and `currencyCode` properties, and either one or both can be set to achieve the desired outcome. `locale` is used for the string formatting, eg using a `,` and placement of the currency symbol, and `currencyCode` is used to set the appropriate symbol.

This PR extends `MPNumericTextField` to also have a `currencyCode` property.

It would have been nice to include nullable annotations in the updated declarations to show that `code` can be nil, but that would required updating all the methods.